### PR TITLE
Try to fix CI check by excluding devcontainer.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+        exclude: .devcontainer/devcontainer.json
       - id: check-toml
       - id: check-xml
       - id: check-yaml


### PR DESCRIPTION
`devcontainer.json` is actually not valid JSON because comments cannot be part of JSON files